### PR TITLE
Prevent PersistentPreRunE to skip compose file detection for network ls

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -140,9 +140,18 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Skip file detection for commands that don't need it
-		if cmd.Name() == "help" || cmd.Name() == "completion" || cmd.Name() == "doctor" || cmd.Name() == "ls" || cmd.Name() == "version" {
+		if cmd.Name() == "help" || cmd.Name() == "completion" || cmd.Name() == "doctor" || cmd.Name() == "version" {
 			logger.Printf("Skipping compose file detection for command: %s", cmd.Name())
 			return nil
+		}
+
+		// Special handling for "ls" command
+		if cmd.Name() == "ls" {
+			// "image ls" doesn't need compose file
+			if cmd.Parent() != nil && cmd.Parent().Name() == "image" {
+				logger.Printf("Skipping compose file detection for command: image ls")
+				return nil
+			}
 		}
 
 		// If -f flag was not provided, try environment variable or default files


### PR DESCRIPTION
Closes #8

All `ls` commands was skipping compose file detection, I made in sort that only `images ls` should skip compose file detection

```shell
$ qemu-compose network ls
Using compose file: /home/user/Documents/qemu-compose/examples/qemu-compose.yaml
Project: qemu-compose

=== Networks ===
NAME                 DRIVER     SUBNET               BRIDGE          DHCP       DNSMASQ UNIT
--------------------------------------------------------------------------------------------------------------
default              bridge     not allocated        qc-qemu-compose no         -

=== Bridges ===
Bridge: qc-qemu-compose (network: default)
  Status: not created

=== TAP Devices ===
No TAP devices found

=== Network Capabilities ===
✅ qemu-compose has CAP_NET_ADMIN capability
   Binary: /home/user/Documents/qemu-compose/bin/qemu-compose
   Capabilities: /home/user/Documents/qemu-compose/bin/qemu-compose cap_net_admin=ep

Testing bridge creation capability...
✅ Can create bridges (sufficient privileges)
```